### PR TITLE
Hotfix: Avoid error in small cls layers

### DIFF
--- a/net2brain/evaluations/encoding.py
+++ b/net2brain/evaluations/encoding.py
@@ -89,8 +89,7 @@ def encode_layer(trn_Idx, tst_Idx, feat_path, layer_id, avg_across_feat, batch_s
                     raise ValueError("Elements in activations do not have the same shape. "
                                      "Please set 'avg_across_feat' to True to average across features.")
                 all_data_for_estim.append(new_activation)  # collect in a list
-            target_dim = min(all_data_for_estim[0].shape[0], johnson_lindenstrauss_min_dim(len(all_data_for_estim)))
-            srp = SparseRandomProjection(n_components=target_dim)
+            srp = SparseRandomProjection(n_components=johnson_lindenstrauss_min_dim(len(all_data_for_estim)))
             srp.fit(np.stack(all_data_for_estim, axis=0))
             if save_pca:
                 with open(save_path.split('pca.pkl')[0]+'srp.pkl', "wb") as f:

--- a/net2brain/evaluations/encoding.py
+++ b/net2brain/evaluations/encoding.py
@@ -9,6 +9,7 @@ import pickle
 from scipy.stats import pearsonr, spearmanr, ttest_1samp, sem
 from sklearn.model_selection import train_test_split, GridSearchCV, ShuffleSplit, cross_val_score
 from sklearn.decomposition import IncrementalPCA
+from sklearn.random_projection import johnson_lindenstrauss_min_dim
 from sklearn.random_projection import SparseRandomProjection
 from sklearn.linear_model import LinearRegression, Ridge
 from sklearn.preprocessing import StandardScaler
@@ -76,7 +77,6 @@ def encode_layer(trn_Idx, tst_Idx, feat_path, layer_id, avg_across_feat, batch_s
     if save_path is None or not os.path.exists(save_path):
 
         if srp_before_pca:
-            srp = SparseRandomProjection()
             all_data_for_estim = []
             srp_trn = trn_Idx if srp_on_subset is None else trn_Idx[:srp_on_subset]
             for jj, ii in enumerate(srp_trn):
@@ -89,6 +89,8 @@ def encode_layer(trn_Idx, tst_Idx, feat_path, layer_id, avg_across_feat, batch_s
                     raise ValueError("Elements in activations do not have the same shape. "
                                      "Please set 'avg_across_feat' to True to average across features.")
                 all_data_for_estim.append(new_activation)  # collect in a list
+            target_dim = min(all_data_for_estim[0].shape[0], johnson_lindenstrauss_min_dim(len(all_data_for_estim)))
+            srp = SparseRandomProjection(n_components=target_dim)
             srp.fit(np.stack(all_data_for_estim, axis=0))
             if save_pca:
                 with open(save_path.split('pca.pkl')[0]+'srp.pkl', "wb") as f:


### PR DESCRIPTION
In the case of layers with very few features like classification layers, the automatic estimation of components in SRP raises an error if it cannot find a valid dimension to reduce to. 
This is a case we want to handle simply by skipping the dimensionality reduction, as the output space of the models should not be reduced.
The error is not raised when SRP gets an explicit number of components (instead only a warning is raised), so a solution that seems to work well is estimating the components first and then passing them explicitly.