### PR TITLE
Add MoCoV3 models

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ To delve deeper into the toolbox, check out our [ReadTheDocs](https://net2brain.
 
 # Updates 
 
+# Updates 08/26
+1. **New netset** `MoCoV3`, with self-supervised ResNet50 (100/300/1000 epochs) and ViT-S/ViT-B (300 epochs) encoders trained on ImageNet
+
+
 # Updates 02/26
 1. Improved Algonauts 2023 NSD datasets (`Algonauts23_Net2Brain` and `Algonauts23_shared_Net2Brain`): proper metadata files linking fMRI rows to image filenames, NSD IDs, COCO IDs and captions, explicit per-subject ROI availability, and recomputed RDMs for the shared split.
 
@@ -349,6 +353,7 @@ This toolbox is inspired by the Algonauts Project and contains collections of ar
 - **CORnet-Z and CORnet-RT:** Kubilius, J., Schrimpf, M., Nayebi, A., Bear, D., Yamins, D.L.K., DiCarlo, J.J. (2018) CORnet: Modeling the Neural Mechanisms of Core Object Recognition. biorxiv. doi:10.1101/408385
 - **CORnet-S:** Kubilius, J., Schrimpf, M., Kar, K., Rajalingham, R., Hong, H., Majaj, N., ... & Dicarlo, J. (2019). Brain-like object recognition with high-performing shallow recurrent ANNs. In Advances in Neural Information Processing Systems (pp. 12785-12796).
 - **MoCo:** Kaiming He and Haoqi Fan and Yuxin Wu and Saining Xie and Ross Girshick, Momentum Contrast for Unsupervised Visual Representation Learning (2019), arXiv preprint arXiv:1911.05722
+- **MoCo v3:** Xinlei Chen and Saining Xie and Kaiming He, An Empirical Study of Training Self-Supervised Vision Transformers (2021), Proceedings of the IEEE/CVF International Conference on Computer Vision (ICCV), arXiv:2104.02057
 - **SwAv:** Caron, Mathilde and Misra, Ishan and Mairal, Julien and Goyal, Priya and Bojanowski, Piotr and Joulin, Armand ,Unsupervised Learning of Visual Features by Contrasting Cluster Assignments (2020), Proceedings of Advances in Neural Information Processing Systems (NeurIPS)
 - **Taskonomy:** Zamir, Amir R and Sax, Alexander and and Shen, William B and Guibas, Leonidas and Malik, Jitendra and Savarese, Silvio, Taskonomy: Disentangling Task Transfer Learning (2018), 2018 IEEE Conference on Computer Vision and Pattern Recognition (CVPR)
 - **Image Models:** Ross Wightman, PyTorch Image Models(2019), 10.5281/zenodo.4414861, https://github.com/rwightman/pytorch-image-models

--- a/docs/source/existing_models.rst
+++ b/docs/source/existing_models.rst
@@ -14,13 +14,13 @@ Available Netsets
 
 **Net2Brain** facilitates the exploration and utilization of a vast range of Deep Neural Networks (DNNs) through its diverse netsets, which are libraries of different pre-trained models:
 
-1. **Standard torchvision** (`Pytorch`)
+1. **Standard torchvision** (`Standard`)
    A compendium of torchvision models catering to a spectrum of tasks from image classification to video classification. Detailed information can be found on the `torchvision models page <https://pytorch.org/vision/stable/models.html>`_.
 
 2. **Timm** (`Timm`)
    A library containing a rich array of advanced computer vision models developed by Ross Wightman. More details are available on the `Timm GitHub repository <https://github.com/rwightman/pytorch-image-models#models>`_.
 
-3. **PyTorch Hub** (`Torchhub`)
+3. **PyTorch Hub** (`Pytorch`)
    This netset includes models for a variety of visual tasks accessible through the torch.hub API, not encompassed by torchvision. For more, see the `PyTorch Hub documentation <https://pytorch.org/docs/stable/hub.html>`_.
 
 4. **MMAction** (`MMAction`)
@@ -46,6 +46,12 @@ Available Netsets
 
 11. **Toolbox** (`Toolbox`)
     A set of networks that are implemented within Net2Brain itself, providing immediate access to specialized neural network functionalities.
+
+12. **Audio** (`Audio`)
+    Networks that take audio as input, such as the PANNs family of audio tagging models. Learn more at the `PANNs GitHub repository <https://github.com/qiuqiangkong/audioset_tagging_cnn>`_.
+
+13. **MoCo v3** (`MoCoV3`)
+    Self-supervised ResNet50 and Vision Transformer encoders trained on ImageNet with momentum contrastive learning, useful as a contrast to supervised training of the same architectures. Details are on the `MoCo v3 GitHub repository <https://github.com/facebookresearch/moco-v3>`_.
 
 
 Adding Your Own Models

--- a/net2brain/architectures/configs/mocov3.json
+++ b/net2brain/architectures/configs/mocov3.json
@@ -1,5 +1,5 @@
 {
-    "vit_base": {
+    "vit_base_300ep": {
         "model": ".implemented_models.mocov3_models.vit_base_300ep",
         "nodes": [
             "blocks.0",
@@ -16,7 +16,7 @@
             "blocks.11"
         ]
     },
-    "vit_small": {
+    "vit_small_300ep": {
         "model": ".implemented_models.mocov3_models.vit_small_300ep",
         "nodes": [
             "blocks.0",

--- a/net2brain/architectures/configs/mocov3.json
+++ b/net2brain/architectures/configs/mocov3.json
@@ -1,0 +1,63 @@
+{
+    "vit_base": {
+        "model": ".implemented_models.mocov3_models.vit_base_300ep",
+        "nodes": [
+            "blocks.0",
+            "blocks.1",
+            "blocks.2",
+            "blocks.3",
+            "blocks.4",
+            "blocks.5",
+            "blocks.6",
+            "blocks.7",
+            "blocks.8",
+            "blocks.9",
+            "blocks.10",
+            "blocks.11"
+        ]
+    },
+    "vit_small": {
+        "model": ".implemented_models.mocov3_models.vit_small_300ep",
+        "nodes": [
+            "blocks.0",
+            "blocks.1",
+            "blocks.2",
+            "blocks.3",
+            "blocks.4",
+            "blocks.5",
+            "blocks.6",
+            "blocks.7",
+            "blocks.8",
+            "blocks.9",
+            "blocks.10",
+            "blocks.11"
+        ]
+    },
+    "resnet50_100ep": {
+        "model": ".implemented_models.mocov3_models.resnet50_100ep",
+        "nodes": [
+            "layer1",
+            "layer2",
+            "layer3",
+            "layer4"
+        ]
+    },
+    "resnet50_300ep": {
+        "model": ".implemented_models.mocov3_models.resnet50_300ep",
+        "nodes": [
+            "layer1",
+            "layer2",
+            "layer3",
+            "layer4"
+        ]
+    },
+    "resnet50_1000ep": {
+        "model": ".implemented_models.mocov3_models.resnet50_1000ep",
+        "nodes": [
+            "layer1",
+            "layer2",
+            "layer3",
+            "layer4"
+        ]
+    }
+}

--- a/net2brain/architectures/implemented_models/mocov3_models.py
+++ b/net2brain/architectures/implemented_models/mocov3_models.py
@@ -11,9 +11,8 @@
 # Modifications made by Net2Brain:
 # - adapt to Timm version 0.4.12
 
-import os
 import math
-import requests
+import warnings
 import torch
 import torch.nn as nn
 import torchvision.models as torchvision_models
@@ -24,13 +23,22 @@ from timm.models.vision_transformer import VisionTransformer, _cfg
 from timm.models.layers.helpers import to_2tuple
 from timm.models.layers import PatchEmbed
 
+from ..netsetbase import CACHE_DIR
+from ..shared_functions import download_to_path
+
 
 ###### COPIED FROM MOCOV3 OFFICIAL REPO###
 __all__ = [
-    'vit_small', 
+    'vit_small',
     'vit_base',
     'vit_conv_small',
     'vit_conv_base',
+    # Net2Brain entry points referenced by configs/mocov3.json
+    'vit_small_300ep',
+    'vit_base_300ep',
+    'resnet50_100ep',
+    'resnet50_300ep',
+    'resnet50_1000ep',
 ]
 
 
@@ -155,19 +163,25 @@ def vit_conv_base(**kwargs):
     return model
 
 def load_state_dict(file_url, linear_keyword):
-    if not os.path.exists(r"checkpoints"):
-        os.makedirs(r"checkpoints")
-    # Check if the file exists in the current directory
-    checkpoint_name = os.path.split(file_url)[-1]
-    checkpoint_path = "checkpoints/"+checkpoint_name
-    if not os.path.exists(checkpoint_path):
-        # Download the file using requests
-        r = requests.get(file_url)
-        print("~ Downloading weights")
-        with open(checkpoint_path, "wb") as f:
-            f.write(r.content)
+    # Cache the checkpoint alongside the other Net2Brain downloads
+    checkpoint_dir = CACHE_DIR / "mocov3_checkpoints"
+    checkpoint_dir.mkdir(parents=True, exist_ok=True)
+    checkpoint_path = checkpoint_dir / file_url.rsplit("/", 1)[-1]
 
-    checkpoint = torch.load(checkpoint_path, map_location="cpu")
+    if not checkpoint_path.exists():
+        print(f"~ Downloading weights to {checkpoint_path}")
+        download_to_path(file_url, checkpoint_path)
+
+    try:
+        checkpoint = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
+    except Exception:
+        # A cached file that cannot be read is unusable, e.g. left over from an
+        # interrupted download. Discard it and fetch the checkpoint once more.
+        warnings.warn(f"Cached checkpoint {checkpoint_path} is unreadable, re-downloading.")
+        checkpoint_path.unlink(missing_ok=True)
+        download_to_path(file_url, checkpoint_path)
+        checkpoint = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
+
     state_dict = checkpoint['state_dict']
     for k in list(state_dict.keys()):
         # retain only base_encoder up to before the embedding layer
@@ -178,62 +192,73 @@ def load_state_dict(file_url, linear_keyword):
         del state_dict[k]
     return state_dict
 
+
+def load_pretrained_weights(model, file_url, linear_keyword):
+    """Load MoCo v3 weights into `model` and verify that they actually arrived.
+
+    Only the (unused) linear classification head is expected to stay randomly
+    initialized. Anything else missing means the checkpoint layout changed and the
+    features would silently be extracted from an untrained network.
+    """
+    state_dict = load_state_dict(file_url, linear_keyword)
+    msg = model.load_state_dict(state_dict, strict=False)
+
+    expected_missing = {'%s.weight' % linear_keyword, '%s.bias' % linear_keyword}
+    unexpected_missing = set(msg.missing_keys) - expected_missing
+    if unexpected_missing or msg.unexpected_keys:
+        raise RuntimeError(
+            f"MoCo v3 checkpoint {file_url} does not match the model definition. "
+            f"Missing keys: {sorted(unexpected_missing)}. "
+            f"Unexpected keys: {sorted(msg.unexpected_keys)}."
+        )
+    return model
+
 def vit_base_300ep(pretrained: bool=True, **kwargs):
-    
+
     model = vit_base()
     file_url = "https://dl.fbaipublicfiles.com/moco-v3/vit-b-300ep/vit-b-300ep.pth.tar"
-    linear_keyword = "head"
     if pretrained:
-        state_dict = load_state_dict(file_url, linear_keyword)
-        msg=model.load_state_dict(state_dict, strict=False)
+        load_pretrained_weights(model, file_url, linear_keyword="head")
 
     model.eval()
     return model
 
 def vit_small_300ep(pretrained: bool=True, **kwargs):
-    
+
     model = vit_small()
     file_url = "https://dl.fbaipublicfiles.com/moco-v3/vit-s-300ep/vit-s-300ep.pth.tar"
-    linear_keyword = "head"
     if pretrained:
-        state_dict = load_state_dict(file_url, linear_keyword)
-        msg=model.load_state_dict(state_dict, strict=False)
+        load_pretrained_weights(model, file_url, linear_keyword="head")
 
     model.eval()
     return model
 
 def resnet50_100ep(pretrained: bool=True, **kwargs):
-    
+
     model = torchvision_models.__dict__['resnet50']()
     file_url = "https://dl.fbaipublicfiles.com/moco-v3/r-50-100ep/r-50-100ep.pth.tar"
-    linear_keyword = "fc"
     if pretrained:
-        state_dict = load_state_dict(file_url, linear_keyword)
-        msg=model.load_state_dict(state_dict, strict=False)
+        load_pretrained_weights(model, file_url, linear_keyword="fc")
 
     model.eval()
     return model
 
 def resnet50_300ep(pretrained: bool=True, **kwargs):
-    
+
     model = torchvision_models.__dict__['resnet50']()
     file_url = "https://dl.fbaipublicfiles.com/moco-v3/r-50-300ep/r-50-300ep.pth.tar"
-    linear_keyword = "fc"
     if pretrained:
-        state_dict = load_state_dict(file_url, linear_keyword)
-        msg=model.load_state_dict(state_dict, strict=False)
+        load_pretrained_weights(model, file_url, linear_keyword="fc")
 
-    model.eval()    
+    model.eval()
     return model
 
 def resnet50_1000ep(pretrained: bool=True, **kwargs):
-    
+
     model = torchvision_models.__dict__['resnet50']()
     file_url = "https://dl.fbaipublicfiles.com/moco-v3/r-50-1000ep/r-50-1000ep.pth.tar"
-    linear_keyword = "fc"
     if pretrained:
-        state_dict = load_state_dict(file_url, linear_keyword)
-        msg=model.load_state_dict(state_dict, strict=False)
+        load_pretrained_weights(model, file_url, linear_keyword="fc")
 
     model.eval()
     return model

--- a/net2brain/architectures/implemented_models/mocov3_models.py
+++ b/net2brain/architectures/implemented_models/mocov3_models.py
@@ -1,0 +1,239 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates. All rights reserved.
+#
+# This file contains code adapted and restructured from Meta's MoCo v3 repository:
+# https://github.com/facebookresearch/moco-v3
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Modifications made by Net2Brain:
+# - adapt to Timm version 0.4.12
+
+import os
+import math
+import requests
+import torch
+import torch.nn as nn
+import torchvision.models as torchvision_models
+from functools import partial, reduce
+from operator import mul
+
+from timm.models.vision_transformer import VisionTransformer, _cfg
+from timm.models.layers.helpers import to_2tuple
+from timm.models.layers import PatchEmbed
+
+
+###### COPIED FROM MOCOV3 OFFICIAL REPO###
+__all__ = [
+    'vit_small', 
+    'vit_base',
+    'vit_conv_small',
+    'vit_conv_base',
+]
+
+
+class VisionTransformerMoCo(VisionTransformer):
+    def __init__(self, stop_grad_conv1=False, **kwargs):
+        super().__init__(**kwargs)
+        # Use fixed 2D sin-cos position embedding
+        self.build_2d_sincos_position_embedding()
+
+        # weight initialization
+        for name, m in self.named_modules():
+            if isinstance(m, nn.Linear):
+                if 'qkv' in name:
+                    # treat the weights of Q, K, V separately
+                    val = math.sqrt(6. / float(m.weight.shape[0] // 3 + m.weight.shape[1]))
+                    nn.init.uniform_(m.weight, -val, val)
+                else:
+                    nn.init.xavier_uniform_(m.weight)
+                nn.init.zeros_(m.bias)
+        nn.init.normal_(self.cls_token, std=1e-6)
+
+        if isinstance(self.patch_embed, PatchEmbed):
+            # xavier_uniform initialization
+            val = math.sqrt(6. / float(3 * reduce(mul, self.patch_embed.patch_size, 1) + self.embed_dim))
+            nn.init.uniform_(self.patch_embed.proj.weight, -val, val)
+            nn.init.zeros_(self.patch_embed.proj.bias)
+
+            if stop_grad_conv1:
+                self.patch_embed.proj.weight.requires_grad = False
+                self.patch_embed.proj.bias.requires_grad = False
+
+    def build_2d_sincos_position_embedding(self, temperature=10000.):
+        h, w = self.patch_embed.grid_size
+        grid_w = torch.arange(w, dtype=torch.float32)
+        grid_h = torch.arange(h, dtype=torch.float32)
+        grid_w, grid_h = torch.meshgrid(grid_w, grid_h)
+        assert self.embed_dim % 4 == 0, 'Embed dimension must be divisible by 4 for 2D sin-cos position embedding'
+        pos_dim = self.embed_dim // 4
+        omega = torch.arange(pos_dim, dtype=torch.float32) / pos_dim
+        omega = 1. / (temperature**omega)
+        out_w = torch.einsum('m,d->md', [grid_w.flatten(), omega])
+        out_h = torch.einsum('m,d->md', [grid_h.flatten(), omega])
+        pos_emb = torch.cat([torch.sin(out_w), torch.cos(out_w), torch.sin(out_h), torch.cos(out_h)], dim=1)[None, :, :]
+
+        assert self.num_tokens == 1, 'Assuming one and only one token, [cls]'
+        pe_token = torch.zeros([1, 1, self.embed_dim], dtype=torch.float32)
+        self.pos_embed = nn.Parameter(torch.cat([pe_token, pos_emb], dim=1))
+        self.pos_embed.requires_grad = False
+
+
+class ConvStem(nn.Module):
+    """ 
+    ConvStem, from Early Convolutions Help Transformers See Better, Tete et al. https://arxiv.org/abs/2106.14881
+    """
+    def __init__(self, img_size=224, patch_size=16, in_chans=3, embed_dim=768, norm_layer=None, flatten=True):
+        super().__init__()
+
+        assert patch_size == 16, 'ConvStem only supports patch size of 16'
+        assert embed_dim % 8 == 0, 'Embed dimension must be divisible by 8 for ConvStem'
+
+        img_size = to_2tuple(img_size)
+        patch_size = to_2tuple(patch_size)
+        self.img_size = img_size
+        self.patch_size = patch_size
+        self.grid_size = (img_size[0] // patch_size[0], img_size[1] // patch_size[1])
+        self.num_patches = self.grid_size[0] * self.grid_size[1]
+        self.flatten = flatten
+
+        # build stem, similar to the design in https://arxiv.org/abs/2106.14881
+        stem = []
+        input_dim, output_dim = 3, embed_dim // 8
+        for l in range(4):
+            stem.append(nn.Conv2d(input_dim, output_dim, kernel_size=3, stride=2, padding=1, bias=False))
+            stem.append(nn.BatchNorm2d(output_dim))
+            stem.append(nn.ReLU(inplace=True))
+            input_dim = output_dim
+            output_dim *= 2
+        stem.append(nn.Conv2d(input_dim, embed_dim, kernel_size=1))
+        self.proj = nn.Sequential(*stem)
+
+        self.norm = norm_layer(embed_dim) if norm_layer else nn.Identity()
+
+    def forward(self, x):
+        B, C, H, W = x.shape
+        assert H == self.img_size[0] and W == self.img_size[1], \
+            f"Input image size ({H}*{W}) doesn't match model ({self.img_size[0]}*{self.img_size[1]})."
+        x = self.proj(x)
+        if self.flatten:
+            x = x.flatten(2).transpose(1, 2)  # BCHW -> BNC
+        x = self.norm(x)
+        return x
+
+
+def vit_small(**kwargs):
+    model = VisionTransformerMoCo(
+        patch_size=16, embed_dim=384, depth=12, num_heads=12, mlp_ratio=4, qkv_bias=True,
+        norm_layer=partial(nn.LayerNorm, eps=1e-6), **kwargs)
+    model.default_cfg = _cfg()
+    return model
+
+def vit_base(**kwargs):
+    model = VisionTransformerMoCo(
+        patch_size=16, embed_dim=768, depth=12, num_heads=12, mlp_ratio=4, qkv_bias=True,
+        norm_layer=partial(nn.LayerNorm, eps=1e-6), **kwargs)
+    model.default_cfg = _cfg()
+    return model
+
+def vit_conv_small(**kwargs):
+    # minus one ViT block
+    model = VisionTransformerMoCo(
+        patch_size=16, embed_dim=384, depth=11, num_heads=12, mlp_ratio=4, qkv_bias=True,
+        norm_layer=partial(nn.LayerNorm, eps=1e-6), embed_layer=ConvStem, **kwargs)
+    model.default_cfg = _cfg()
+    return model
+
+def vit_conv_base(**kwargs):
+    # minus one ViT block
+    model = VisionTransformerMoCo(
+        patch_size=16, embed_dim=768, depth=11, num_heads=12, mlp_ratio=4, qkv_bias=True,
+        norm_layer=partial(nn.LayerNorm, eps=1e-6), embed_layer=ConvStem, **kwargs)
+    model.default_cfg = _cfg()
+    return model
+
+def load_state_dict(file_url, linear_keyword):
+    if not os.path.exists(r"checkpoints"):
+        os.makedirs(r"checkpoints")
+    # Check if the file exists in the current directory
+    checkpoint_name = os.path.split(file_url)[-1]
+    checkpoint_path = "checkpoints/"+checkpoint_name
+    if not os.path.exists(checkpoint_path):
+        # Download the file using requests
+        r = requests.get(file_url)
+        print("~ Downloading weights")
+        with open(checkpoint_path, "wb") as f:
+            f.write(r.content)
+
+    checkpoint = torch.load(checkpoint_path, map_location="cpu")
+    state_dict = checkpoint['state_dict']
+    for k in list(state_dict.keys()):
+        # retain only base_encoder up to before the embedding layer
+        if k.startswith('module.base_encoder') and not k.startswith('module.base_encoder.%s' % linear_keyword):
+            # remove prefix
+            state_dict[k[len("module.base_encoder."):]] = state_dict[k]
+        # delete renamed or unused k
+        del state_dict[k]
+    return state_dict
+
+def vit_base_300ep(pretrained: bool=True, **kwargs):
+    
+    model = vit_base()
+    file_url = "https://dl.fbaipublicfiles.com/moco-v3/vit-b-300ep/vit-b-300ep.pth.tar"
+    linear_keyword = "head"
+    if pretrained:
+        state_dict = load_state_dict(file_url, linear_keyword)
+        msg=model.load_state_dict(state_dict, strict=False)
+
+    model.eval()
+    return model
+
+def vit_small_300ep(pretrained: bool=True, **kwargs):
+    
+    model = vit_small()
+    file_url = "https://dl.fbaipublicfiles.com/moco-v3/vit-s-300ep/vit-s-300ep.pth.tar"
+    linear_keyword = "head"
+    if pretrained:
+        state_dict = load_state_dict(file_url, linear_keyword)
+        msg=model.load_state_dict(state_dict, strict=False)
+
+    model.eval()
+    return model
+
+def resnet50_100ep(pretrained: bool=True, **kwargs):
+    
+    model = torchvision_models.__dict__['resnet50']()
+    file_url = "https://dl.fbaipublicfiles.com/moco-v3/r-50-100ep/r-50-100ep.pth.tar"
+    linear_keyword = "fc"
+    if pretrained:
+        state_dict = load_state_dict(file_url, linear_keyword)
+        msg=model.load_state_dict(state_dict, strict=False)
+
+    model.eval()
+    return model
+
+def resnet50_300ep(pretrained: bool=True, **kwargs):
+    
+    model = torchvision_models.__dict__['resnet50']()
+    file_url = "https://dl.fbaipublicfiles.com/moco-v3/r-50-300ep/r-50-300ep.pth.tar"
+    linear_keyword = "fc"
+    if pretrained:
+        state_dict = load_state_dict(file_url, linear_keyword)
+        msg=model.load_state_dict(state_dict, strict=False)
+
+    model.eval()    
+    return model
+
+def resnet50_1000ep(pretrained: bool=True, **kwargs):
+    
+    model = torchvision_models.__dict__['resnet50']()
+    file_url = "https://dl.fbaipublicfiles.com/moco-v3/r-50-1000ep/r-50-1000ep.pth.tar"
+    linear_keyword = "fc"
+    if pretrained:
+        state_dict = load_state_dict(file_url, linear_keyword)
+        msg=model.load_state_dict(state_dict, strict=False)
+
+    model.eval()
+    return model

--- a/net2brain/architectures/mocov3_models.py
+++ b/net2brain/architectures/mocov3_models.py
@@ -7,7 +7,7 @@ import os
 class MoCoV3(NetSetBase):
 
     def __init__(self, model_name, device):
-        self.supported_data_types = ['image']
+        self.supported_data_types = ['image', 'video']
         self.netset_name = "MoCoV3"
         self.model_name = model_name
         self.device = device
@@ -21,12 +21,17 @@ class MoCoV3(NetSetBase):
     def get_preprocessing_function(self, data_type):
         if data_type == 'image':
             return self.image_preprocessing
+        elif data_type == 'video':
+            warnings.warn("Models only support image-data. Will average video frames")
+            return self.video_preprocessing
         else:
             raise ValueError(f"Unsupported data type for {self.netset_name}: {data_type}")
-        
+
 
     def get_feature_cleaner(self, data_type):
         if data_type == 'image':
+            return MoCoV3.clean_extracted_features
+        elif data_type == 'video':
             return MoCoV3.clean_extracted_features
         else:
             raise ValueError(f"Unsupported data type for {self.netset_name}: {data_type}")

--- a/net2brain/architectures/mocov3_models.py
+++ b/net2brain/architectures/mocov3_models.py
@@ -1,0 +1,75 @@
+import warnings
+from .netsetbase import NetSetBase
+from .shared_functions import load_from_json
+import torchextractor as tx
+import os
+
+class MoCoV3(NetSetBase):
+
+    def __init__(self, model_name, device):
+        self.supported_data_types = ['image']
+        self.netset_name = "MoCoV3"
+        self.model_name = model_name
+        self.device = device
+
+        # Set config path:
+        file_path = os.path.abspath(__file__)
+        directory_path = os.path.dirname(file_path)
+        self.config_path = os.path.join(directory_path, "configs/mocov3.json")
+
+
+    def get_preprocessing_function(self, data_type):
+        if data_type == 'image':
+            return self.image_preprocessing
+        else:
+            raise ValueError(f"Unsupported data type for {self.netset_name}: {data_type}")
+        
+
+    def get_feature_cleaner(self, data_type):
+        if data_type == 'image':
+            return MoCoV3.clean_extracted_features
+        else:
+            raise ValueError(f"Unsupported data type for {self.netset_name}: {data_type}")
+        
+
+
+
+    def get_model(self, pretrained):
+
+        # Load attributes from the json
+        model_attributes = load_from_json(self.config_path, self.model_name)
+
+        # Set the layers and model function from the attributes
+        self.layers = model_attributes["nodes"]
+        self.loaded_model = model_attributes["model_function"](pretrained=pretrained)
+
+        # Model to device
+        self.loaded_model.to(self.device)
+
+        # Randomize weights
+        if not pretrained:
+            self.loaded_model.apply(self.randomize_weights)
+
+        # Put in eval mode
+        self.loaded_model.eval()
+
+        return self.loaded_model
+
+
+    def clean_extracted_features(self, features):
+        return features
+    
+    
+    def extraction_function(self, data, layers_to_extract=None, model=None):
+
+        self.layers = self.select_model_layers(layers_to_extract, self.layers, self.loaded_model)
+
+        # Create a extractor instance
+        self.extractor_model = tx.Extractor(self.loaded_model, self.layers)
+
+        # Extract actual features
+        _, features = self.extractor_model(data)
+
+        return features
+
+         

--- a/net2brain/architectures/shared_functions.py
+++ b/net2brain/architectures/shared_functions.py
@@ -2,9 +2,9 @@ import warnings
 import json
 import importlib
 from pathlib import Path
-import shutil
 import requests
 import urllib.request
+from tqdm import tqdm
 
 
 def get_function_from_module(function_string):
@@ -30,9 +30,19 @@ def get_function_from_module(function_string):
 
 def download_to_path(url: str, dest: Path) -> None:
     tmp = dest.with_suffix(dest.suffix + ".tmp")
-    with urllib.request.urlopen(url) as r, open(tmp, "wb") as f:
-        shutil.copyfileobj(r, f)
-    tmp.replace(dest)  # atomic-ish move
+    try:
+        with urllib.request.urlopen(url) as r, open(tmp, "wb") as f:
+            total = int(r.headers.get("Content-Length") or 0)
+            with tqdm(total=total or None, unit="B", unit_scale=True, unit_divisor=1024,
+                      desc=dest.name) as progress:
+                for chunk in iter(lambda: r.read(1024 * 1024), b""):
+                    f.write(chunk)
+                    progress.update(len(chunk))
+        tmp.replace(dest)  # atomic-ish move
+    finally:
+        # Never leave a partial download behind: it would be mistaken for a
+        # complete checkpoint on the next run and fail to load forever.
+        tmp.unlink(missing_ok=True)
 
 
 def download_github_folder(owner, repo, repo_path, out_dir):

--- a/net2brain/architectures/taxonomy.csv
+++ b/net2brain/architectures/taxonomy.csv
@@ -693,3 +693,8 @@ Data,MMAction,uniformer_v2_B_16_CLIP_k710_k400,,,,,,,,,x,,,,,x,,,,,,,,,,,,,,,,x,
 Data,MMAction,videomae_B,,,,,,,,,x,,,,,x,,,,,,,,,,,,,,,,x,,,x,,,,,,,,
 Data,MMAction,videomae_v2_S,,,,,,,,,x,,,,,x,,,,,,,,,,,,,,,,x,,,x,,,,,,,,
 Data,MMAction,videomae_v2_B,,,,,,,,,x,,,,,x,,,,,,,,,,,,,,,,x,,,x,,,,,,,,
+Data,MoCoV3,vit_base_300ep,x,,,,,,,,,,,,,,,x,,,x,,,,,,,,,,,,,,,,,,,,,,x
+Data,MoCoV3,vit_small_300ep,x,,,,,,,,,,,,,,,x,,,x,,,,,,,,,,,,,,,,,,,,,,x
+Data,MoCoV3,resnet50_100ep,x,,,,,,,,,,,x,,,,,,,x,,,,,,,,,,,,,,,,,,,,,,x
+Data,MoCoV3,resnet50_300ep,x,,,,,,,,,,,x,,,,,,,x,,,,,,,,,,,,,,,,,,,,,,x
+Data,MoCoV3,resnet50_1000ep,x,,,,,,,,,,,x,,,,,,,x,,,,,,,,,,,,,,,,,,,,,,x

--- a/net2brain/feature_extraction.py
+++ b/net2brain/feature_extraction.py
@@ -14,6 +14,7 @@ from .architectures.unet_models import Unet
 from .architectures.yolo_models import Yolo
 from .architectures.huggingface_llm import Huggingface
 from .architectures.audio_models import Audio
+from .architectures.mocov3_models import MoCoV3
 from datetime import datetime
 import torchextractor as tx
 import warnings

--- a/net2brain/tests/test_feature_extraction.py
+++ b/net2brain/tests/test_feature_extraction.py
@@ -16,6 +16,8 @@ from net2brain.feature_extraction import FeatureExtractor
         ("Taskonomy", "colorization"),
         ("Clip", "RN50"),
         ("Cornet", "cornet_z"),
+        ("MoCoV3", "vit_small_300ep"),
+        ("MoCoV3", "resnet50_100ep"),
     ],
 )
 def test_extractor_outputs(root_path, tmp_path, netset, model):


### PR DESCRIPTION
### Summary of changes
This PR adds support for **MoCo v3 (Momentum Contrast v3)** self-supervised models to the library. Model checkpoints and code are taken from https://github.com/facebookresearch/moco-v3 using the pretrain files (without trained linear head). The following backbones are included:

- ResNet50 pre-trained for 100, 300 and 1000 epochs respectively
- ViT-Base pre-trained for 300 epochs
- ViT-Small pre-trained for 300 epochs

### Reason for change
@sari-saba-sadiya, @t9s9 and I used the models together with Net2Brain for another project and figured it would be great to have them available permanently in Net2Brain.

### Example code
For using the models for feature extraction, use e.g.
```
from net2brain.feature_extraction import FeatureExtractor

fx = FeatureExtractor(model='resnet50_300ep', netset='MoCoV3', device='cpu')
```

### Reviewer
@ToastyDom (I don't have permission to officially assign you using the sidebar)

